### PR TITLE
fix(useCreateTaskModal): fix custom hook to avoid multiple

### DIFF
--- a/src/hooks/useCreateTaskModal.ts
+++ b/src/hooks/useCreateTaskModal.ts
@@ -2,10 +2,15 @@ import { useCreateTask } from "./useTasks"; // El hook que creamos antes
 import { useFormErrorContext } from "@/context/FormErrorContext";
 import { TaskSchema } from "@/schemas/taskSchema";
 import { FormError } from "@/types/data";
+import { useState } from "react";
 
 export const useCreateTaskModal = (boardId: string) => {
-  const { mutateAsync: createTask, isPending } = useCreateTask(boardId);
+  const { mutateAsync: createTask, isPending: isMutationPending } =
+    useCreateTask(boardId);
   const { errors, setErrors } = useFormErrorContext();
+
+  const [isNavigating, setIsNavigating] = useState(false);
+  const isPending = isMutationPending || isNavigating;
 
   const handleSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -45,6 +50,7 @@ export const useCreateTaskModal = (boardId: string) => {
     }
 
     try {
+      setErrors(undefined);
       await createTask({
         title,
         description,
@@ -52,7 +58,9 @@ export const useCreateTaskModal = (boardId: string) => {
         subtasks,
         priorityId: 1,
       });
+      setIsNavigating(true);
     } catch (error: unknown) {
+      setIsNavigating(false);
       if (error instanceof Error) {
         setErrors({
           serverError: `Error: ${error.message}`,


### PR DESCRIPTION
fix tasks creation when spamming create task button

- button now stays disabled after clicking as expected

## Summary
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update

## How to Test
1. fill create task form with valid data
2. click the create task button multiple times 
3. Only one task was created

## Checklist:
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code (especially in complex areas).
- [ ] I have updated the documentation (if applicable).
- [x] My changes do not generate new warnings.

