### PR TITLE
refactor: implement handleClickOutside for ConfirmationModal

### DIFF
--- a/src/components/modals/ConfirmationModal.tsx
+++ b/src/components/modals/ConfirmationModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+import { useEffect, useRef } from "react";
 import SecondaryButton from "../shared/buttons/SecondaryButton";
 
 interface ConfirmationModalProps {
@@ -15,29 +17,62 @@ export default function ConfirmationModal({
   onClose,
   isPending,
 }: ConfirmationModalProps) {
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white dark:bg-black-400 p-8 rounded-lg max-w-md w-full mx-4">
-        <h2 className="text-red-500 heading-l mb-6">{title}</h2>
-        <p className="text-grey-300 body-l mb-8">{description}</p>
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
-        <div className="flex flex-col md:flex-row gap-4">
-          <SecondaryButton
-            onClick={onConfirm}
-            disabled={isPending ?? false}
-            className="flex-1 bg-red-500! text-white"
-          >
-            {isPending ? "Deleting..." : "Delete"}
-          </SecondaryButton>
-          <SecondaryButton
-            onClick={onClose}
-            disabled={isPending ?? false}
-            className="flex-1"
-          >
-            Cancel
-          </SecondaryButton>
-        </div>
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog) {
+      dialog.showModal();
+    }
+
+    return () => dialog?.close();
+  }, []);
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
+    const dialogDimensions = dialogRef.current?.getBoundingClientRect();
+    if (!dialogDimensions) return;
+
+    if (
+      e.clientX < dialogDimensions.left ||
+      e.clientX > dialogDimensions.right ||
+      e.clientY < dialogDimensions.top ||
+      e.clientY > dialogDimensions.bottom
+    ) {
+      onClose();
+    }
+  };
+
+  const handleCancel = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    onClose();
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onCancel={handleCancel}
+      onClick={handleBackdropClick}
+      className="backdrop:bg-black/50 mx-auto my-auto bg-white dark:bg-black-400 p-8 rounded-lg max-w-md w-full border-none shadow-xl fixed"
+    >
+      <h2 className="text-red-500 heading-l mb-6">{title}</h2>
+      <p className="text-grey-300 body-l mb-8">{description}</p>
+
+      <div className="flex flex-col md:flex-row gap-4">
+        <SecondaryButton
+          onClick={onConfirm}
+          disabled={isPending ?? false}
+          className="flex-1 bg-red-500! text-white"
+        >
+          {isPending ? "Deleting..." : "Delete"}
+        </SecondaryButton>
+        <SecondaryButton
+          onClick={onClose}
+          disabled={isPending ?? false}
+          className="flex-1"
+        >
+          Cancel
+        </SecondaryButton>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/src/components/shared/ActionMenu.tsx
+++ b/src/components/shared/ActionMenu.tsx
@@ -3,12 +3,18 @@ import { useActionMenu } from "@/hooks/useActionMenu";
 interface ActionMenuProps {
   className?: string;
   onDeleteClick: () => void;
+  onEditClick: () => void;
 }
 
-function ActionMenu({ className, onDeleteClick }: ActionMenuProps) {
+function ActionMenu({
+  className,
+  onDeleteClick,
+  onEditClick,
+}: ActionMenuProps) {
   const { isOpen, menuRef, closeMenu, toggleMenu } = useActionMenu();
   const handleEdit = () => {
     closeMenu();
+    onEditClick();
   };
 
   const handleDelete = () => {

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -8,24 +8,24 @@ import { useBoard, useDeleteBoard } from "@/hooks/useBoards";
 import NavDropodown from "./NavDropdown";
 import { useModalManager } from "@/hooks/useModalManager";
 import ActionMenu from "./ActionMenu";
-import { useState } from "react";
 import ConfirmationModal from "../modals/ConfirmationModal";
+import { useConfirmationModal } from "@/hooks/useConfirmationModal";
 
 interface HeaderProps {
   className?: string;
 }
 
 function Header({ className }: HeaderProps) {
-  const [IsDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { boardId } = useParams();
   const { data: board } = useBoard(boardId as string);
   const { openModal } = useModalManager();
-
+  const { IsDeleteModalOpen, openConfirmationModal, closeConfirmationModal } =
+    useConfirmationModal();
   const { mutate: deleteBoard } = useDeleteBoard();
   const handleDeleteBoard = () => {
     if (boardId) {
       deleteBoard(boardId?.toString());
-      setIsDeleteModalOpen(false);
+      closeConfirmationModal();
     }
   };
   return (
@@ -59,7 +59,10 @@ function Header({ className }: HeaderProps) {
                     + Add New Task
                   </span>
                 </button>
-                <ActionMenu onDeleteClick={() => setIsDeleteModalOpen(true)} />
+                <ActionMenu
+                  onDeleteClick={() => openConfirmationModal()}
+                  onEditClick={() => {}}
+                />
               </>
             )}
           </div>
@@ -70,7 +73,7 @@ function Header({ className }: HeaderProps) {
           title={"Delete this board?"}
           description={`Are you sure you want to delete the '${board?.name}' board? This action will remove all columns and tasks and cannot be reversed.`}
           onConfirm={handleDeleteBoard}
-          onClose={() => setIsDeleteModalOpen(false)}
+          onClose={() => closeConfirmationModal()}
         />
       )}
     </>

--- a/src/hooks/useConfirmationModal.tsx
+++ b/src/hooks/useConfirmationModal.tsx
@@ -1,0 +1,14 @@
+import { useState } from "react";
+
+export const useConfirmationModal = () => {
+  const [IsDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const openConfirmationModal = () => setIsDeleteModalOpen(true);
+  const closeConfirmationModal = () => setIsDeleteModalOpen(false);
+
+  return {
+    IsDeleteModalOpen,
+    setIsDeleteModalOpen,
+    openConfirmationModal,
+    closeConfirmationModal,
+  };
+};


### PR DESCRIPTION
## Summary
now user should be able to close confirmation modal clicking the backdrop
extracted state logic for confirmation modal from header to it's own custom hook.
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update

## Checklist:
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code (especially in complex areas).
- [ ] I have updated the documentation (if applicable).
- [x] My changes do not generate new warnings.

